### PR TITLE
Fix NDI output timestamps

### DIFF
--- a/obs-ndi-output.cpp
+++ b/obs-ndi-output.cpp
@@ -127,7 +127,10 @@ void ndi_output_rawvideo(void *data, struct video_data *frame) {
 	video_frame.frame_rate_D = o->video_info.fps_den;
 	video_frame.picture_aspect_ratio = (float)width / (float)height;
 	video_frame.frame_format_type = NDIlib_frame_format_type_progressive;
-	video_frame.timecode = frame->timestamp;
+	// This will also fix the timestamp issue. More investigation needed if
+	// there is an advantage of one option over the other.
+	// video_frame.timecode = frame->timestamp / 100;
+	video_frame.timecode = NDIlib_send_timecode_synthesize;
 
 	video_frame.p_data = frame->data[0];
 	video_frame.line_stride_in_bytes = frame->linesize[0];
@@ -142,7 +145,8 @@ void ndi_output_rawaudio(void *data, struct audio_data *frame) {
 	NDIlib_audio_frame_t audio_frame = { 0 };
 	audio_frame.sample_rate = o->audio_info.samples_per_sec;
 	audio_frame.no_channels = o->audio_info.speakers;
-	audio_frame.timecode = frame->timestamp;
+	// audio_frame.timecode = frame->timestamp / 100;
+	audio_frame.timecode = NDIlib_send_timecode_synthesize;
 	audio_frame.no_samples = frame->frames;
 	audio_frame.p_data = (float*)(void*)(frame->data[0]);
 


### PR DESCRIPTION
On my system I have some issues with the current ndi output. This seems to be due to timestamps being incorrectly set.

There are two ways to fix this:
* divide timestamp from obs by 100 so it is the correct size (1 interval = 100 ns)
* Rely on the NDI Library itself to generate the timestamp

Both seem to work fine with the software I tested (vMix, XSplit, obs + obs-ndi). According to NewTek's documentation using `NDIlib_send_timecode_synthesize` should be the default so I'm leaning towards using it over the obs timestamp.