### PR TITLE
[src] Fix simple warnings during compile

### DIFF
--- a/src/obs-ndi-filter.cpp
+++ b/src/obs-ndi-filter.cpp
@@ -96,7 +96,7 @@ obs_properties_t* ndi_filter_getproperties(void* data) {
         #if defined(_WIN32)
             ShellExecute(NULL, "open", "http://ndi.newtek.com", NULL, NULL, SW_SHOWNORMAL);
         #elif defined(__linux__) || defined(__APPLE__)
-            system("open http://ndi.newtek.com");
+            int suppresswarning = system("open http://ndi.newtek.com");
         #endif
 
         return true;

--- a/src/obs-ndi-source.cpp
+++ b/src/obs-ndi-source.cpp
@@ -142,7 +142,7 @@ obs_properties_t* ndi_source_getproperties(void* data) {
         #if defined(_WIN32)
             ShellExecute(NULL, "open", "http://ndi.newtek.com", NULL, NULL, SW_SHOWNORMAL);
         #elif defined(__linux__) || defined(__APPLE__)
-            system("open http://ndi.newtek.com");
+            int suppresswarning = system("open http://ndi.newtek.com");
         #endif
 
         return true;
@@ -351,7 +351,7 @@ void ndi_source_update(void* data, obs_data_t* settings) {
     if (s->ndi_receiver) {
         if (hwAccelEnabled) {
             NDIlib_metadata_frame_t hwAccelMetadata;
-            hwAccelMetadata.p_data = "<ndi_hwaccel enabled=\"true\"/>";
+            hwAccelMetadata.p_data = (char*)"<ndi_hwaccel enabled=\"true\"/>";
             ndiLib->NDIlib_recv_send_metadata(
                 s->ndi_receiver, &hwAccelMetadata);
         }


### PR DESCRIPTION
Simple fixes for compiler warnings when compiling this module under Linux (at least).

Does not add/remove any feature or functions but simple adds enough code to suppress
the warnings created during compile time.

```
~/git/obs-ndi/build$ make clean all -j8
[ 10%] Automatic moc and uic for target obs-ndi
Generating ui_output-settings.h
Generating moc_output-settings.cpp
[ 10%] Built target obs-ndi_automoc
Scanning dependencies of target obs-ndi
[ 20%] Building CXX object CMakeFiles/obs-ndi.dir/src/forms/output-settings.cpp.o
[ 30%] Building CXX object CMakeFiles/obs-ndi.dir/src/obs-ndi.cpp.o
[ 40%] Building CXX object CMakeFiles/obs-ndi.dir/src/Config.cpp.o
[ 50%] Building CXX object CMakeFiles/obs-ndi.dir/obs-ndi_automoc.cpp.o
[ 60%] Building CXX object CMakeFiles/obs-ndi.dir/src/obs-ndi-source.cpp.o
[ 70%] Building CXX object CMakeFiles/obs-ndi.dir/src/obs-ndi-filter.cpp.o
[ 80%] Building CXX object CMakeFiles/obs-ndi.dir/src/premultiplied-alpha-filter.cpp.o
[ 90%] Building CXX object CMakeFiles/obs-ndi.dir/src/obs-ndi-output.cpp.o
/home/dx/git/obs-ndi/src/obs-ndi-filter.cpp: In lambda function:
/home/dx/git/obs-ndi/src/obs-ndi-filter.cpp:99:49: warning: ignoring return value of ‘int system(const char*)’, declared with attribute warn_unused_result [-Wunused-result]
             system("open http://ndi.newtek.com");
                                                 ^
/home/dx/git/obs-ndi/src/obs-ndi-source.cpp: In function ‘void ndi_source_update(void*, obs_data_t*)’:
/home/dx/git/obs-ndi/src/obs-ndi-source.cpp:354:36: warning: ISO C++ forbids converting a string constant to ‘char*’ [-Wwrite-strings]
             hwAccelMetadata.p_data = "<ndi_hwaccel enabled=\"true\"/>";
                                    ^
/home/dx/git/obs-ndi/src/obs-ndi-source.cpp: In lambda function:
/home/dx/git/obs-ndi/src/obs-ndi-source.cpp:145:49: warning: ignoring return value of ‘int system(const char*)’, declared with attribute warn_unused_result [-Wunused-result]
             system("open http://ndi.newtek.com");
                                                 ^
[100%] Linking CXX shared module obs-ndi.so
[100%] Built target obs-ndi
```


now:
``` 
~/git/obs-ndi/build$ make clean all -j8
Scanning dependencies of target obs-ndi_automoc
[ 10%] Automatic moc and uic for target obs-ndi
Generating ui_output-settings.h
Generating moc_output-settings.cpp
[ 10%] Built target obs-ndi_automoc
Scanning dependencies of target obs-ndi
[ 20%] Building CXX object CMakeFiles/obs-ndi.dir/src/obs-ndi-source.cpp.o
[ 30%] Building CXX object CMakeFiles/obs-ndi.dir/src/obs-ndi-filter.cpp.o
[ 40%] Building CXX object CMakeFiles/obs-ndi.dir/src/obs-ndi.cpp.o
[ 50%] Building CXX object CMakeFiles/obs-ndi.dir/src/forms/output-settings.cpp.o
[ 60%] Building CXX object CMakeFiles/obs-ndi.dir/src/obs-ndi-output.cpp.o
[ 70%] Building CXX object CMakeFiles/obs-ndi.dir/obs-ndi_automoc.cpp.o
[ 80%] Building CXX object CMakeFiles/obs-ndi.dir/src/Config.cpp.o
[ 90%] Building CXX object CMakeFiles/obs-ndi.dir/src/premultiplied-alpha-filter.cpp.o
[100%] Linking CXX shared module obs-ndi.so
[100%] Built target obs-ndi 
```