### PR TITLE
Reduce active CPU usage by 80%, disconnected CPU usage by ~ 95%

### DIFF
--- a/src/obs-ndi-source.cpp
+++ b/src/obs-ndi-source.cpp
@@ -23,6 +23,8 @@ along with this program; If not, see <https://www.gnu.org/licenses/>
 #include <obs-module.h>
 #include <util/platform.h>
 #include <util/threading.h>
+#include <chrono>
+#include <thread>
 
 #include "obs-ndi.h"
 
@@ -319,6 +321,9 @@ void* ndi_source_poll_audio(void* data)
 
 			obs_source_output_audio(s->source, &obs_audio_frame);
 			ndiLib->NDIlib_recv_free_audio_v2(s->ndi_receiver, &audio_frame);
+		} else if (ndiLib->NDIlib_recv_get_no_connections(s->ndi_receiver) == 0) {
+			std::this_thread::sleep_for(std::chrono::milliseconds(100));
+			continue;
 		}
 	}
 
@@ -391,6 +396,9 @@ void* ndi_source_poll_video(void* data)
 
 			obs_source_output_video(s->source, &obs_video_frame);
 			ndiLib->NDIlib_recv_free_video_v2(s->ndi_receiver, &video_frame);
+		} else if (ndiLib->NDIlib_recv_get_no_connections(s->ndi_receiver) == 0) {
+			std::this_thread::sleep_for(std::chrono::milliseconds(100));
+			continue;
 		}
 	}
 


### PR DESCRIPTION
- receiving returns immediately if not connected, meaning the poll threads are busy-looping. Add a 100ms sleep in these threads if disconnected to avoid this
- profiling shows that libndi has a mutex when receiving frames - so trying to pull frames in two threads is slower than pulling in one. Move to one thread
- now that we're in one thread, we can block the poll for as long as we like - poll without a timeout of 100ms instead of 1ms

Results:
- When there is no NDI transmitter on the network: before: 2 cores at 100% + 1 at 80%  after: 1 core at 20% which is pretty much what OBS takes up without NDI
- When there is an active source: before 2 cores at 100% + 1 at 60%. after: 1 core at 60%

fixes #70