### PR TITLE
Docs: Add QTDIR CMake entry to build steps in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ You'll need CMake and a working development environment for OBS Studio installed
 
 ### Windows
 In cmake-gui, you'll have to set these CMake variables :
+- **QTDIR** (path) : location of the Qt environment suited for your compiler and architecture
 - **LIBOBS_INCLUDE_DIR** (path) : location of the libobs subfolder in the source code of OBS Studio
 - **LIBOBS_LIB** (filepath) : location of the obs.lib file
 - **OBS_FRONTEND_LIB** (filepath) : location of the obs-frontend-api.lib file


### PR DESCRIPTION
While attempting to build obs-ndi, I got a config error that Qt could not be found.  After adding a CMake entry for "QTDIR" I could build just fine.  I noticed that the README does not mention requiring Qt or specifying QTDIR.  While "a working development environment for OBS Studio" does imply needing Qt installed for that, I felt it would be helpful to explicitly specify that QTDIR must be specified for this build, just like obs-websocket does.