### PR TITLE
ci(macos): fix lookup path of Qt dependencies for new OBS bundle format

### DIFF
--- a/CI/before-deploy-osx.sh
+++ b/CI/before-deploy-osx.sh
@@ -12,9 +12,12 @@ export LATEST_FILENAME="obs-ndi-latest-$LATEST_VERSION.pkg"
 cd ./installer
 
 install_name_tool \
-	-change "/usr/local/opt/qt/lib/QtWidgets.framework/Versions/5/QtWidgets" @executable_path/../Frameworks/QtWidgets.framework/Versions/5/QtWidgets \
-	-change "/usr/local/opt/qt/lib/QtGui.framework/Versions/5/QtGui" @executable_path/../Frameworks/QtGui.framework/Versions/5/QtGui \
-	-change "/usr/local/opt/qt/lib/QtCore.framework/Versions/5/QtCore" @executable_path/../Frameworks/QtCore.framework/Versions/5/QtCore \
+	-add_rpath @executable_path/../Frameworks/QtWidgets.framework/Versions/5/ \
+	-add_rpath @executable_path/../Frameworks/QtGui.framework/Versions/5/ \
+	-add_rpath @executable_path/../Frameworks/QtCore.framework/Versions/5/ \
+	-change "/usr/local/opt/qt/lib/QtWidgets.framework/Versions/5/QtWidgets" @rpath/QtWidgets \
+	-change "/usr/local/opt/qt/lib/QtGui.framework/Versions/5/QtGui" @rpath/QtGui \
+	-change "/usr/local/opt/qt/lib/QtCore.framework/Versions/5/QtCore" @rpath/QtCore \
 	../build/obs-ndi.so
 
 # Check if replacement worked

--- a/CI/before-deploy-osx.sh
+++ b/CI/before-deploy-osx.sh
@@ -12,9 +12,9 @@ export LATEST_FILENAME="obs-ndi-latest-$LATEST_VERSION.pkg"
 cd ./installer
 
 install_name_tool \
-	-change "/usr/local/opt/qt/lib/QtWidgets.framework/Versions/5/QtWidgets" @rpath/QtWidgets \
-	-change "/usr/local/opt/qt/lib/QtGui.framework/Versions/5/QtGui" @rpath/QtGui \
-	-change "/usr/local/opt/qt/lib/QtCore.framework/Versions/5/QtCore" @rpath/QtCore \
+	-change "/usr/local/opt/qt/lib/QtWidgets.framework/Versions/5/QtWidgets" @executable_path/../Frameworks/QtWidgets.framework/Versions/5/QtWidgets \
+	-change "/usr/local/opt/qt/lib/QtGui.framework/Versions/5/QtGui" @executable_path/../Frameworks/QtWidgets.framework/Versions/5/QtGui \
+	-change "/usr/local/opt/qt/lib/QtCore.framework/Versions/5/QtCore" @executable_path/../Frameworks/QtWidgets.framework/Versions/5/QtCore \
 	../build/obs-ndi.so
 
 # Check if replacement worked

--- a/CI/before-deploy-osx.sh
+++ b/CI/before-deploy-osx.sh
@@ -13,8 +13,8 @@ cd ./installer
 
 install_name_tool \
 	-change "/usr/local/opt/qt/lib/QtWidgets.framework/Versions/5/QtWidgets" @executable_path/../Frameworks/QtWidgets.framework/Versions/5/QtWidgets \
-	-change "/usr/local/opt/qt/lib/QtGui.framework/Versions/5/QtGui" @executable_path/../Frameworks/QtWidgets.framework/Versions/5/QtGui \
-	-change "/usr/local/opt/qt/lib/QtCore.framework/Versions/5/QtCore" @executable_path/../Frameworks/QtWidgets.framework/Versions/5/QtCore \
+	-change "/usr/local/opt/qt/lib/QtGui.framework/Versions/5/QtGui" @executable_path/../Frameworks/QtGui.framework/Versions/5/QtGui \
+	-change "/usr/local/opt/qt/lib/QtCore.framework/Versions/5/QtCore" @executable_path/../Frameworks/QtCore.framework/Versions/5/QtCore \
 	../build/obs-ndi.so
 
 # Check if replacement worked


### PR DESCRIPTION
To do :
- [x] Keep the current @rpath lookup as a fallback for older OBS versions