### PR TITLE
installer(macos): don't automatically install the NDI runtime

### DIFF
--- a/installer/obs-ndi.pkgproj
+++ b/installer/obs-ndi.pkgproj
@@ -990,9 +990,6 @@
 				<key>VERSION</key>
 				<integer>5</integer>
 			</dict>
-			<key>PACKAGE_SCRIPTS</key>
-			<dict>
-			</dict>
 			<key>PACKAGE_SETTINGS</key>
 			<dict>
 				<key>AUTHENTICATION</key>

--- a/installer/obs-ndi.pkgproj
+++ b/installer/obs-ndi.pkgproj
@@ -992,15 +992,6 @@
 			</dict>
 			<key>PACKAGE_SCRIPTS</key>
 			<dict>
-				<key>PREINSTALL_PATH</key>
-				<dict>
-					<key>PATH</key>
-					<string>osx-install-ndi-runtime.sh</string>
-					<key>PATH_TYPE</key>
-					<integer>1</integer>
-				</dict>
-				<key>RESOURCES</key>
-				<array/>
 			</dict>
 			<key>PACKAGE_SETTINGS</key>
 			<dict>

--- a/installer/osx-install-ndi-runtime.sh
+++ b/installer/osx-install-ndi-runtime.sh
@@ -1,6 +1,0 @@
-#!/bin/bash
-set -ex
-cd /tmp
-rm -f ndiruntime.pkg
-curl -L -o ndiruntime.pkg http://new.tk/NDIRedistV4Apple
-sudo installer -allowUntrusted -package ./ndiruntime.pkg -target /


### PR DESCRIPTION
Not only is it a functional nightmare, but it's also a security nightmare. In the installation instructions, users will now be asked to download the NDI runtime separately.

Fixes #388 
Fixes #412 