### PR TITLE
Ubuntu packaging fixes

### DIFF
--- a/CI/package-ubuntu.sh
+++ b/CI/package-ubuntu.sh
@@ -32,6 +32,7 @@ cd ./build
 PAGER="cat" sudo checkinstall -y --type=debian --fstrans=no --nodoc \
 	--backup=no --deldoc=yes --install=no \
 	--pkgname=obs-ndi --pkgversion="$PKG_VERSION" \
+        --summary="NewTek NDI integration for OBS Studio" \
 	--pkglicense="GPLv2" --maintainer="stephane.lepin@gmail.com" \
 	--requires="obs-studio \(\>= 25.0.7\), libndi4 \(\>= ${NDILIB_VERSION}\)" --pkggroup="video" \
 	--pkgsource="https://github.com/Palakis/obs-ndi" \
@@ -40,6 +41,7 @@ PAGER="cat" sudo checkinstall -y --type=debian --fstrans=no --nodoc \
 PAGER="cat" sudo checkinstall -y --type=debian --fstrans=no --nodoc \
         --backup=no --deldoc=yes --install=no \
         --pkgname=libndi4 --replaces=libndi3 --pkgversion="$NDILIB_VERSION" \
+        --summary="NDI $NDILIB_VERSION Runtime" \
         --pkglicense="Proprietary" --maintainer="stephane.lepin@gmail.com" \
        	--pkggroup="video" \
         --pkgsource="http://ndi.newtek.com" \
@@ -48,6 +50,7 @@ PAGER="cat" sudo checkinstall -y --type=debian --fstrans=no --nodoc \
 PAGER="cat" sudo checkinstall -y --type=debian --fstrans=no --nodoc \
         --backup=no --deldoc=yes --install=no \
         --pkgname=libndi4-dev --pkgversion="$NDILIB_VERSION" --requires="libndi4>=$NDILIB_VERSION" \
+        --summary="Development files and headers for the NDI $NDILIB_VERSION Runtime" \
         --pkglicense="Proprietary" --maintainer="stephane.lepin@gmail.com" \
         --pkggroup="video" \
         --pkgsource="http://ndi.newtek.com" \

--- a/CI/package-ubuntu.sh
+++ b/CI/package-ubuntu.sh
@@ -33,7 +33,7 @@ PAGER="cat" sudo checkinstall -y --type=debian --fstrans=no --nodoc \
 	--backup=no --deldoc=yes --install=no \
 	--pkgname=obs-ndi --pkgversion="$PKG_VERSION" \
 	--pkglicense="GPLv2" --maintainer="stephane.lepin@gmail.com" \
-	--requires="libndi4>=$NDILIB_VERSION" --pkggroup="video" \
+	--requires="obs-studio>=25.0.7,libndi4>=$NDILIB_VERSION" --pkggroup="video" \
 	--pkgsource="https://github.com/Palakis/obs-ndi" \
 	--pakdir="../package"
 

--- a/CI/package-ubuntu.sh
+++ b/CI/package-ubuntu.sh
@@ -33,7 +33,7 @@ PAGER="cat" sudo checkinstall -y --type=debian --fstrans=no --nodoc \
 	--backup=no --deldoc=yes --install=no \
 	--pkgname=obs-ndi --pkgversion="$PKG_VERSION" \
 	--pkglicense="GPLv2" --maintainer="stephane.lepin@gmail.com" \
-	--requires="obs-studio>=25.0.7,libndi4>=$NDILIB_VERSION" --pkggroup="video" \
+	--requires="obs-studio \(\>= 25.0.7\), libndi4 \(\>= ${NDILIB_VERSION}\)" --pkggroup="video" \
 	--pkgsource="https://github.com/Palakis/obs-ndi" \
 	--pakdir="../package"
 

--- a/CI/package-ubuntu.sh
+++ b/CI/package-ubuntu.sh
@@ -32,7 +32,6 @@ cd ./build
 PAGER="cat" sudo checkinstall -y --type=debian --fstrans=no --nodoc \
 	--backup=no --deldoc=yes --install=no \
 	--pkgname=obs-ndi --pkgversion="$PKG_VERSION" \
-        --summary="NewTek NDI integration for OBS Studio" \
 	--pkglicense="GPLv2" --maintainer="stephane.lepin@gmail.com" \
 	--requires="obs-studio \(\>= 25.0.7\), libndi4 \(\>= ${NDILIB_VERSION}\)" --pkggroup="video" \
 	--pkgsource="https://github.com/Palakis/obs-ndi" \
@@ -41,7 +40,6 @@ PAGER="cat" sudo checkinstall -y --type=debian --fstrans=no --nodoc \
 PAGER="cat" sudo checkinstall -y --type=debian --fstrans=no --nodoc \
         --backup=no --deldoc=yes --install=no \
         --pkgname=libndi4 --replaces=libndi3 --pkgversion="$NDILIB_VERSION" \
-        --summary="NDI $NDILIB_VERSION Runtime" \
         --pkglicense="Proprietary" --maintainer="stephane.lepin@gmail.com" \
        	--pkggroup="video" \
         --pkgsource="http://ndi.newtek.com" \
@@ -50,7 +48,6 @@ PAGER="cat" sudo checkinstall -y --type=debian --fstrans=no --nodoc \
 PAGER="cat" sudo checkinstall -y --type=debian --fstrans=no --nodoc \
         --backup=no --deldoc=yes --install=no \
         --pkgname=libndi4-dev --pkgversion="$NDILIB_VERSION" --requires="libndi4>=$NDILIB_VERSION" \
-        --summary="Development files and headers for the NDI $NDILIB_VERSION Runtime" \
         --pkglicense="Proprietary" --maintainer="stephane.lepin@gmail.com" \
         --pkggroup="video" \
         --pkgsource="http://ndi.newtek.com" \

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -151,21 +151,14 @@ endif()
 
 # Linux
 if(UNIX AND NOT APPLE)
+	include(GNUInstallDirs)
+
 	set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11 -mtune=core2 -Ofast")
 
-	if(ARCH EQUAL 64)
-		set(ARCH_NAME "x86_64")
-	else()
-		set(ARCH_NAME "i686")
-	endif()
-
 	set_target_properties(obs-ndi PROPERTIES PREFIX "")
-
-	target_link_libraries(obs-ndi
-		obs-frontend-api)
+	target_link_libraries(obs-ndi obs-frontend-api)
 
 	file(GLOB locale_files data/locale/*.ini)
-        execute_process(COMMAND uname -m COMMAND tr -d '\n' OUTPUT_VARIABLE UNAME_MACHINE)
 
 	install(TARGETS obs-ndi
                 LIBRARY DESTINATION ${CMAKE_INSTALL_FULL_LIBDIR}/obs-plugins)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -168,11 +168,8 @@ if(UNIX AND NOT APPLE)
         execute_process(COMMAND uname -m COMMAND tr -d '\n' OUTPUT_VARIABLE UNAME_MACHINE)
 
 	install(TARGETS obs-ndi
-                LIBRARY DESTINATION ${CMAKE_INSTALL_PREFIX}/lib/obs-plugins)
-	# Dirty fix for Ubuntu
-	install(TARGETS obs-ndi
-		LIBRARY DESTINATION ${CMAKE_INSTALL_PREFIX}/lib/${UNAME_MACHINE}-linux-gnu/obs-plugins)
+                LIBRARY DESTINATION ${CMAKE_INSTALL_FULL_LIBDIR}/obs-plugins)
 
 	install(FILES ${locale_files}
-		DESTINATION "${CMAKE_INSTALL_PREFIX}/share/obs/obs-plugins/obs-ndi/locale")
+		DESTINATION "${CMAKE_INSTALL_FULL_DATAROOTDIR}/obs/obs-plugins/obs-ndi/locale")
 endif()


### PR DESCRIPTION
- [x] Make the deb package require OBS v25.0.7 or higher
- [x] Remove the "Ubuntu dirty hack" from CMakeLists.txt and use standard GNU locations
