### PR TITLE
CMakeLists: Compiles for arm targets

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,6 +9,10 @@ set(CMAKE_AUTOUIC ON)
 set(CMAKE_CXX_STANDARD 11)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
+if (${CMAKE_SYSTEM_PROCESSOR} MATCHES "arm") 
+    set(CMAKE_CXX_FLAGS "-mfpu=neon")
+endif()
+
 if (WIN32 OR APPLE)
     include(external/FindLibObs.cmake)
 endif()
@@ -153,7 +157,11 @@ endif()
 if(UNIX AND NOT APPLE)
 	include(GNUInstallDirs)
 
-	set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11 -mtune=core2 -Ofast")
+	if (${CMAKE_SYSTEM_PROCESSOR} MATCHES "arm") 
+		set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11 -mtune=arm7 -Ofast")
+	else()
+		set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11 -mtune=core2 -Ofast")
+	endif()
 
 	set_target_properties(obs-ndi PROPERTIES PREFIX "")
 	target_link_libraries(obs-ndi obs-frontend-api)


### PR DESCRIPTION
With the merge of pr [#3180 on obs-studio](https://github.com/obsproject/obs-studio/pull/3180), we can now compile the obs-ndi plugin to build and install on arm devices like the raspberry pi.  I ran the code on a Raspberry Pi 3B+ running Raspberry Pi OS 2015-05-05 with this [build script](https://github.com/venepe/install-obs-raspberry-pi.git).  

It will fix this bug:
<img width="857" alt="Screen Shot 2020-07-18 at 1 38 03 PM" src="https://user-images.githubusercontent.com/13398476/87859623-13ef8700-c8fc-11ea-84cb-52616b2de47c.png">
