### PR TITLE
Change audio output to use synthetic timecode.

### DIFF
--- a/src/obs-ndi-output.cpp
+++ b/src/obs-ndi-output.cpp
@@ -321,7 +321,7 @@ void ndi_output_rawaudio(void* data, struct audio_data* frame)
 	}
 
 	audio_frame.p_data = o->audio_conv_buffer;
-	audio_frame.timecode = (int64_t)(frame->timestamp / 100);
+	audio_frame.timecode = NDIlib_send_timecode_synthesize;
 
 	ndiLib->send_send_audio_v3(o->ndi_sender, &audio_frame);
 }


### PR DESCRIPTION
I had audio/video sync issues trying to use the NDI plugin to feed OBS video and audio into NDI and then on to Zoom.

After a lot of fiddling around, I found that the culprit was OBS/this plugin. I could use the NDI monitor to see the video + audio output and although they would start in sync they would gradually drift apart, which was pretty useless!

It seems like lots of people have been experiencing similar things with the video/audio sync of the output:

* #375 
* #379
* #498 
* #530
* #534 

In the end, I made a single line change and now the sync is near-perfect.

This single line has a very long history, and rightly so!

1. In 95c1d2ce21bd9bd6ee27161b5b67344ec605c917 the timestamp on the video and audio was changed from using the OBS timestamp to letting NDI synthesize the timestamp.
2. Then in d8d3952173ad5538ae8f19117e24540843d19cdd it was changed back to using the OBS timestamp from the audio frame. Note that at this point there was a TODO to determine what was the best thing to do.
3. In 57ae3a3fbb3a603b430e5362831f478337bca3ef this TODO was removed as part of general code style refactor, maybe the comment wasn't actioned it was just bad style?

It's changed a little bit since then, but fundamentally it's the same line of code: use the OBS timestamp for video and audio.

So, history lesson over, back to the single line change.
I added some super simple logging to output the timestamp of the frames we are getting from OBS in the raw_video and raw_audio callbacks, and the timestamps were essentially the same for the first couple but began to drift fairly quickly, they were literally seconds apart after 15 minutes. Maybe there's an OBS bug around the timestamps that are sent along, since the audio data seemed fine, it was simply out of sync.

I'm totally new of OBS so don't understand the internals really at all, but as far as I can tell, the video output is performed by a thread that's waiting for frames from the render, and that it's clocked at the framerate of the video. Then it looks like the audio thread generally tries to keep up with the video rendering, once a video frame goes out the corresponding audio frames are sent out too.

Assuming my understanding is correct then we should simply rely on the OBS timestamp from the *video* only, and let NDI synthesize the audio timecode, since the NDI library will do its thing and the audio will get the timecode of the previously sent video frame.

In my limited testing, this works just fine, and is a decent workaround for this plugin to use.

Maybe this should be raised as an upstream issue in OBS too, since it looks like the timestamps coming out of OBS audio frames are plain wrong.