### PR TITLE
4.10.2: Fix ndi source audio handling, and other cleanups

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -6,7 +6,7 @@ on:
       - '**.md'
     branches:
       - master
-      - main
+      - develop
     tags:
       - '*'
   pull_request:
@@ -14,7 +14,7 @@ on:
       - '**.md'
     branches:
       - master
-      - main
+      - develop
 
 env:
   PLUGIN_NAME: 'obs-ndi'

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.16...3.21)
 
-project(obs-ndi VERSION 4.10.0)
+project(obs-ndi VERSION 4.10.1)
 add_library(${CMAKE_PROJECT_NAME} MODULE)
 
 set(PLUGIN_AUTHOR "tt2468")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.16...3.21)
 
-project(obs-ndi VERSION 4.9.1)
+project(obs-ndi VERSION 4.10.0)
 add_library(${CMAKE_PROJECT_NAME} MODULE)
 
 set(PLUGIN_AUTHOR "tt2468")

--- a/buildspec.json
+++ b/buildspec.json
@@ -82,5 +82,5 @@
         }
     },
     "name": "obs-ndi",
-    "version": "4.9.1"
+    "version": "4.10.0"
 }

--- a/buildspec.json
+++ b/buildspec.json
@@ -82,5 +82,5 @@
         }
     },
     "name": "obs-ndi",
-    "version": "4.10.0"
+    "version": "4.10.1"
 }

--- a/src/obs-ndi-source.cpp
+++ b/src/obs-ndi-source.cpp
@@ -341,9 +341,14 @@ void *ndi_source_poll_audio_video(void *data)
 			ndiLib->recv_capture_v3(s->ndi_receiver, &video_frame,
 						&audio_frame, nullptr, 100);
 
-		int channelCount = (int)fmin(8, audio_frame.no_channels);
 		if (frame_received == NDIlib_frame_type_audio) {
+
 			if (s->audio_enabled) {
+				const int channelCount =
+					audio_frame.no_channels > 8
+						? 8
+						: audio_frame.no_channels;
+
 				obs_audio_frame.speakers =
 					channel_count_to_layout(channelCount);
 
@@ -369,10 +374,8 @@ void *ndi_source_poll_audio_video(void *data)
 
 				for (int i = 0; i < channelCount; ++i) {
 					obs_audio_frame.data[i] =
-						(uint8_t *)(&audio_frame.p_data
-								     [i *
-								      audio_frame
-									      .no_samples]);
+						(uint8_t *)audio_frame.p_data +
+						i * audio_frame.channel_stride_in_bytes;
 				}
 
 				obs_source_output_audio(s->source,


### PR DESCRIPTION
### Description
* Refactor to use obsplugin-template compatible with OBS28+
* Fix ndi source audio handling
* Updating code headers to be consistent (I am glad to change the contact from Palakis to someone else that will respond faster)
* Fixing code warnings and restoring `obsplugin-template`'s warnings as errors
* Formatting using indention of 4 whitespaces, never tabs
* Removing files no longer used by obsplugin-template

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes/closes an open issue or implements feature request, -->
<!--- please link to the issue here. -->

### How Has This Been Tested?
* Windows 11
* MacOS pending
* Linux Debian pending

### Types of changes
- Bug fix (non-breaking change which fixes an issue)
- Code cleanup (non-breaking change which makes code smaller or more readable)

### Checklist:
-  [x] I have read the [**contributing** document](https://github.com/Palakis/obs-ndi/blob/rewrite/CONTRIBUTING.md).
-  [ ] My code is not on the master branch.
-  [ ] The code has been tested.
-  [ ] All commit messages are properly formatted and commits squashed where appropriate.
-  [ ] I have included updates to all appropriate documentation.
