### PR TITLE
Add support for BT.2100 color space on NDI input

### DIFF
--- a/src/ndi-source.cpp
+++ b/src/ndi-source.cpp
@@ -65,7 +65,7 @@
 
 #define PROP_YUV_SPACE_BT601 1
 #define PROP_YUV_SPACE_BT709 2
-#define PROP_YUV_SPACE_BT2100 5
+#define PROP_YUV_SPACE_BT2100 3
 
 #define PROP_LATENCY_UNDEFINED -1
 #define PROP_LATENCY_NORMAL 0
@@ -188,7 +188,7 @@ static video_colorspace prop_to_colorspace(int index)
 	case PROP_YUV_SPACE_BT601:
 		return VIDEO_CS_601;
 	case PROP_YUV_SPACE_BT2100:
-		return VIDEO_CS_DEFAULT;
+		return VIDEO_CS_2100_HLG;
 	default:
 	case PROP_YUV_SPACE_BT709:
 		return VIDEO_CS_709;


### PR DESCRIPTION
This PR adds the ability for the user to select BT.2100 as the color space for the an NDI source. It also moves the calculation of the color space conversion matrices to when the user changes the option, instead of recalculating on every frame.

This issue is reported in issue [1333](https://github.com/DistroAV/DistroAV/issues/1333) and is fixed by this PR.

Testing can be done by using the Test Patterns App in NDI Tools. Selecting the HDR option will send NDI in the BT.2100 color space.