### PR TITLE
docs: add AGENTS instructions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@
 !.clang-format
 !.gersemirc
 !.gitignore
+!AGENTS.md
 !buildspec.json
 !CMakeLists.txt
 !CMakePresets.json

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,22 @@
+# AGENTS Instructions
+
+This file provides instructions for contributors and automated tools. It applies to the entire repository.
+
+## Style
+- Use `clang-format` version 16 or later with the included `.clang-format` for all C, C++, Objective-C, and Objective-C++ sources.
+- Ensure each file ends with a trailing newline.
+
+## Build and Test
+After modifying code, run the following commands to make a best effort to build and test the project:
+
+```sh
+cmake --preset ubuntu-x86_64
+cmake --build --preset ubuntu-x86_64
+ctest --test-dir build_x86_64
+```
+
+If any command fails due to missing dependencies, attempt to install them and re-run the command.
+
+## Commit Guidelines
+- Write commit messages in the imperative mood and keep the summary line short.
+- In Pull Request descriptions, summarize the changes and list the build and test commands you executed.


### PR DESCRIPTION
## Summary
- add AGENTS.md describing formatting, build, and commit guidelines
- allow AGENTS.md to be committed by updating .gitignore

## Testing
- `cmake --preset ubuntu-x86_64` *(fails: Could not find package configuration file provided by "LibObs")*
- `cmake --build --preset ubuntu-x86_64` *(fails: loading 'build.ninja': No such file or directory)*
- `ctest --test-dir build_x86_64` *(No tests were found)*


------
https://chatgpt.com/codex/tasks/task_e_68a594cb411483338278cfa0f73698b8