### PR TITLE
Fix filter-chain rendering, Part 2

### DIFF
--- a/src/ndi-filter.cpp
+++ b/src/ndi-filter.cpp
@@ -41,6 +41,7 @@ typedef struct {
 
 	uint32_t known_width;
 	uint32_t known_height;
+	bool rendered;
 
 	gs_texrender_t *texrender;
 	gs_stagesurf_t *stagesurface;
@@ -149,6 +150,9 @@ void ndi_filter_render_video(void *data, gs_effect_t *)
 	auto f = (ndi_filter_t *)data;
 	obs_source_skip_video_filter(f->obs_source);
 
+	if (f->rendered)
+		return;
+
 	obs_source_t *target = obs_filter_get_target(f->obs_source);
 	obs_source_t *parent = obs_filter_get_parent(f->obs_source);
 
@@ -226,6 +230,8 @@ void ndi_filter_render_video(void *data, gs_effect_t *)
 			gs_stagesurface_unmap(f->stagesurface);
 		}
 	}
+
+	f->rendered = true;
 }
 
 void ndi_sender_destroy(ndi_filter_t *filter)
@@ -395,6 +401,8 @@ void ndi_filter_tick(void *data, float)
 {
 	auto f = (ndi_filter_t *)data;
 	obs_get_video_info(&f->ovi);
+
+	f->rendered = false;
 }
 
 obs_audio_data *ndi_filter_asyncaudio(void *data, obs_audio_data *audio_data)


### PR DESCRIPTION
This fixes up some issues that were missed with the first PR in #1343 

- Instead of checking for `obs_source_active` it now checks for `obs_source_showing` to ensure the filter is valid
	- This allows sending the video data when the source is showing in Studio mode for example)
- Removed the NDI sender create logic inside the `ndi_filter_tick` method
	- This was leftover from before the changes to the "timeout" were made when it destroyed the NDI sender when the source became invalid (e.g. hidden, or invalid size)
- Addition of a `rendered` boolean check
	- This ensures it will only render and send the source once, otherwise when it is visible multiple times (e.g. when the Properties window is opened) it will send frames out of order and it will look like it's stuttering (See video below)

https://github.com/user-attachments/assets/6a10af5a-9080-460c-a47e-e894a6bbf861

