### PR TITLE
Send user to NDI Tools download instead of runtime

### DIFF
--- a/src/plugin-main.cpp
+++ b/src/plugin-main.cpp
@@ -280,7 +280,12 @@ bool obs_module_load(void)
 	if (!ndiLib) {
 		auto title = Str("NDIPlugin.LibError.Title");
 		auto message = "Error-401: " + QTStr("NDIPlugin.LibError.Message") + "<br>";
+
+#if defined(NDI_OFFICIAL_TOOLS_URL)
 		message += makeLink(NDI_OFFICIAL_TOOLS_URL);
+#else
+		message += makeLink(NDI_OFFICIAL_WEB_URL);
+#endif
 		obs_log(LOG_ERROR, "ERR-401 - NDI library failed to load with message: '%s'", QT_TO_UTF8(message));
 		obs_log(LOG_DEBUG, "obs_module_load: ERROR - load_ndilib() failed; message=%s", QT_TO_UTF8(message));
 		showCriticalUnloadingMessageBoxDelayed(title, message);


### PR DESCRIPTION
When DistroAV cannot find the NDI libraries, we put up an error dialog and provide a link to download the runtime. The link to the NDI runtime (http://ndi.link/NDIRedistV6) provided in the NDI SDK include file does not work as of 12/17/2025 and hasn't for a while. While we wait for NDI to address the issue, we now send the user to the web page to Download NDI Tools for their platform: https://ndi.video/tools/download

To do this, we use the already existing NDI_OFFICIAL_TOOLS_URL symbol set in plugin-main.h

 

