### PR TITLE
Fix Network based Audio/Video Sync

### DIFF
--- a/src/ndi-source.cpp
+++ b/src/ndi-source.cpp
@@ -758,7 +758,7 @@ void ndi_source_thread_process_audio3(ndi_source_config_t *config, NDIlib_audio_
 
 	switch (config->sync_mode) {
 	case PROP_SYNC_NDI_TIMESTAMP:
-		obs_audio_frame->timestamp = (uint64_t)(ndi_audio_frame->timestamp * 100);
+		obs_audio_frame->timestamp = ndi_audio_frame->timestamp;
 		break;
 
 	case PROP_SYNC_NDI_SOURCE_TIMECODE:
@@ -819,7 +819,7 @@ void ndi_source_thread_process_video2(ndi_source_t *source, NDIlib_video_frame_v
 
 	switch (config->sync_mode) {
 	case PROP_SYNC_NDI_TIMESTAMP:
-		obs_video_frame->timestamp = (uint64_t)(ndi_video_frame->timestamp * 100);
+		obs_video_frame->timestamp = ndi_video_frame->timestamp;
 		break;
 
 	case PROP_SYNC_NDI_SOURCE_TIMECODE:


### PR DESCRIPTION
This fixes a problem we have with the Audio/Video Sync setting of Network.

Problem:
When Network is chosen, the following OBS verbose log messages will get logged...
```
16:23:03.271: Timestamp for source 'NDI Source 2' jumped by '3299999967', expected value 10664201107917214989, input value 10664201111217214956
16:23:03.305: Timestamp for source 'NDI Source 2' jumped by '3299999967', expected value 10664201111250548289, input value 10664201114550548256
16:23:03.337: Timestamp for source 'NDI Source 2' jumped by '3299999967', expected value 10664201114583881589, input value 10664201117883881556
```
This is because the timestamp values of the NDI source is much bigger than expected. In our case the unit of the timestamp is 100th of a nanosecond.

To fix this, we do not need to multiply the timestamp from NDI by 100 when passing on to OBS. It is not clear when this was changed as I do remember the code only multiplied the timecode by 100. 

This is an attempt to fix issue https://github.com/DistroAV/DistroAV/issues/1386 where a user is having issues using NTP on his cameras and in DistroAV.
