### PR TITLE
Start main output and preview after other plugins have setup output

### DIFF
--- a/src/plugin-main.cpp
+++ b/src/plugin-main.cpp
@@ -360,8 +360,14 @@ bool obs_module_load(void)
 		obs_frontend_add_event_callback(
 			[](enum obs_frontend_event event, void *) {
 				if (event == OBS_FRONTEND_EVENT_FINISHED_LOADING) {
-					main_output_init();
-					preview_output_init();
+					auto main_window = static_cast<QMainWindow *>(obs_frontend_get_main_window());
+					QMetaObject::invokeMethod(
+						main_window,
+						[] {
+							main_output_init();
+							preview_output_init();
+						},
+						Qt::QueuedConnection);
 				} else if (event == OBS_FRONTEND_EVENT_EXIT) {
 					// Unknown why putting this in obs_module_unload causes a crash when closing OBS
 					main_output_deinit();


### PR DESCRIPTION
Start main output and preview queued on the UI thread to allow other plugins to configure their canvases

Aitum Stream Suite fails to configure its canvases because there is an output active. The configuration of the canvases is done on OBS_FRONTEND_EVENT_FINISHED_LOADING in Aitum Stream Suite, but OBS_FRONTEND_EVENT_FINISHED_LOADING is called on DistroAV before that.