### PR TITLE
Bump base plugin template files & OBS 31.1.1 requirement

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -81,6 +81,7 @@ PenaltyReturnTypeOnItsOwnLine: 60
 
 PointerAlignment: Right
 ReflowComments: false
+SkipMacroDefinitionBody: true
 SortIncludes: false
 SortUsingDeclarations: false
 SpaceAfterCStyleCast: false
@@ -181,7 +182,7 @@ ReferenceAlignment: Right
 RemoveSemicolon: false
 RequiresClausePosition: WithPreceding
 RequiresExpressionIndentation: OuterScope
-SeparateDefinitionBlocks: Always
+SeparateDefinitionBlocks: Leave
 ShortNamespaceLines: 1
 SortIncludes: false
 #SortUsingDeclarations: LexicographicNumeric

--- a/.gersemirc
+++ b/.gersemirc
@@ -1,11 +1,8 @@
 # yaml-language-server: $schema=https://raw.githubusercontent.com/BlankSpruce/gersemi/master/gersemi/configuration.schema.json
 
-#color: false
 definitions: []
 line_length: 120
 indent: 2
 list_expansion: favour-inlining
-#quiet: false
 unsafe: false
-#workers: 10
 warn_about_unknown_commands: false

--- a/.github/ISSUE_TEMPLATE/1_bug.yml
+++ b/.github/ISSUE_TEMPLATE/1_bug.yml
@@ -17,10 +17,10 @@ body:
       label: "This bug exists on the latest available release of DistroAV and supported environment?"
       description: "Please fill the environment area as well."
       options:
-      - label: "I have checked this bug still exist on the latest available version of DistroAV"
-        required: false
-      - label: "I have checked that my OS / OBS / NDI versions are supported"
-        required: false
+      - label: "I have checked this bug still exist on the latest available version of DistroAV."
+        required: true
+      - label: "I have checked that my OS / OBS / NDI versions are supported & up-to-date."
+        required: true
   - type: input
     id: obs-log
     attributes:
@@ -62,7 +62,7 @@ body:
       description: |
         examples:
           - **OS**: [Ubuntu 22.04, MacOS 15.1, Windows 10 22H2, Win 11 24H2, ...]
-          - **OBS**: [28.0, 29.0.2, 30.2.3 ...] installed from [.exe, .dep, apt, brew, PPA, Flatpak, Snap, winget, ...]
+          - **OBS**: [30.2.3, 31.1, 32.0 ...] installed from [.exe, .dep, apt, brew, PPA, Flatpak, Snap, winget, ...]
           - **DistroAV**: [6.0.0, 6.1 ...] installed from [.exe, .pkg, brew, Flatpak, winget, ...]
           - **NDI**: [5.60, 6.0.1 ...]
       value: |
@@ -86,3 +86,6 @@ body:
         required: false
       - label: "I have tested on a 'clean' OBS installation (aka with no other scripts or plugin installed)"
         required: false
+      - label: "I am filing this bug report as a Human and have reviewed its content to the best of my ability to ensure it's accurate."
+        required: false
+

--- a/.github/ISSUE_TEMPLATE/1_bug.yml
+++ b/.github/ISSUE_TEMPLATE/1_bug.yml
@@ -17,7 +17,7 @@ body:
       label: "This bug exists on the latest available release of DistroAV and supported environment?"
       description: "Please fill the environment area as well."
       options:
-      - label: "I have checked this bug still exist on the latest available version of DistroAV."
+      - label: "I have checked this bug still exists on the latest available version of DistroAV."
         required: true
       - label: "I have checked that my OS / OBS / NDI versions are supported & up-to-date."
         required: true

--- a/.github/ISSUE_TEMPLATE/3_support.yml
+++ b/.github/ISSUE_TEMPLATE/3_support.yml
@@ -31,8 +31,6 @@ body:
       options:
       - label: "I have checked this is not an existing active bug/feature request"
         required: true
-      - label: "I have checked that my OS / OBS / NDI versions are supported"
-        required: true
       - label: "I have followed the NDI Runtime installation steps as described in the Wiki"
         required: true
       - label: "I have followed the DistroAV installation steps as described in the Wiki"
@@ -43,7 +41,7 @@ body:
         required: true
       - label: "My version of OBS is up-to-date"
         required: true
-      - label: "My version of NDI Runtime is up-to date"
+      - label: "My version of NDI Runtime is up-to-date"
         required: true
       - label: "OBS launch without error message (User Interface/popup)"
         required: false
@@ -62,6 +60,10 @@ body:
       - label: "A working NDI feed can be received in 'NDI Studio Monitor'"
         required: false
       - label: "A working NDI feed can be received in OBS"
+        required: false
+      - label: "A human have reviewed this support request to the best of my ability to ensure it's accurate."
+        required: true
+      - label: "This support request is submitted by an AI/Agent"
         required: false
   - type: input
     id: obs-log

--- a/.github/ISSUE_TEMPLATE/3_support.yml
+++ b/.github/ISSUE_TEMPLATE/3_support.yml
@@ -61,7 +61,7 @@ body:
         required: false
       - label: "A working NDI feed can be received in OBS"
         required: false
-      - label: "A human have reviewed this support request to the best of my ability to ensure it's accurate."
+      - label: "A human has reviewed this support request to the best of my ability to ensure it's accurate."
         required: true
       - label: "This support request is submitted by an AI/Agent"
         required: false

--- a/.github/actions/build-plugin/action.yaml
+++ b/.github/actions/build-plugin/action.yaml
@@ -16,6 +16,10 @@ inputs:
     description: Developer ID for application codesigning (macOS only)
     required: false
     default: '-'
+  codesignTeam:
+    description: Team ID for application codesigning (macOS only)
+    required: false
+    default: ''
   workingDirectory:
     description: Working directory for packaging
     required: false

--- a/.github/actions/run-clang-format/action.yaml
+++ b/.github/actions/run-clang-format/action.yaml
@@ -35,7 +35,7 @@ runs:
         echo ::group::Install Dependencies
         eval "$(/home/linuxbrew/.linuxbrew/bin/brew shellenv)"
         echo "/home/linuxbrew/.linuxbrew/bin:/home/linuxbrew/.linuxbrew/sbin" >> $GITHUB_PATH
-        echo "/home/linuxbrew/.linuxbrew/opt/clang-format@17/bin" >> $GITHUB_PATH
+        echo "/home/linuxbrew/.linuxbrew/opt/clang-format@19/bin" >> $GITHUB_PATH
         brew install --quiet zsh
         echo ::endgroup::
 
@@ -50,11 +50,11 @@ runs:
         : Run clang-format 🐉
         if (( ${+RUNNER_DEBUG} )) setopt XTRACE
 
-        print ::group::Install clang-format-17
-        brew install --quiet obsproject/tools/clang-format@17
+        print ::group::Install clang-format-19
+        brew install --quiet obsproject/tools/clang-format@19
         print ::endgroup::
 
-        print ::group::Run clang-format-17
+        print ::group::Run clang-format-19
         local -a changes=(${(s:,:)CHANGED_FILES//[\[\]\'\"]/})
         ./build-aux/run-clang-format --fail-${{ inputs.failCondition }} --check ${changes}
         print ::endgroup::

--- a/.github/scripts/utils.zsh/check_macos
+++ b/.github/scripts/utils.zsh/check_macos
@@ -1,16 +1,5 @@
 autoload -Uz is-at-least log_group log_info log_error log_status
 
-local macos_version=$(sw_vers -productVersion)
-
-log_group 'Install macOS build requirements'
-log_info 'Checking macOS version...'
-if ! is-at-least 11.0 ${macos_version}; then
-  log_error "Minimum required macOS version is 11.0, but running on macOS ${macos_version}"
-  return 2
-else
-  log_status "macOS ${macos_version} is recent"
-fi
-
 log_info 'Checking for Homebrew...'
 if (( ! ${+commands[brew]} )) {
   log_error 'No Homebrew command found. Please install Homebrew (https://brew.sh)'

--- a/.github/scripts/utils.zsh/setup_ubuntu
+++ b/.github/scripts/utils.zsh/setup_ubuntu
@@ -42,6 +42,7 @@ if (( ! (${skips[(Ie)all]} + ${skips[(Ie)deps]}) )) {
     libsimde-dev \
     build-essential \
     libgles2-mesa-dev \
+    libsimde-dev \
     libcurl4-openssl-dev \
     obs-studio
 

--- a/.github/scripts/utils.zsh/setup_ubuntu
+++ b/.github/scripts/utils.zsh/setup_ubuntu
@@ -39,7 +39,6 @@ if (( ! (${skips[(Ie)all]} + ${skips[(Ie)deps]}) )) {
   sudo apt update
 
   sudo apt-get install ${apt_args} \
-    libsimde-dev \
     build-essential \
     libgles2-mesa-dev \
     libsimde-dev \

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -17,7 +17,7 @@
     {
       "name": "macos",
       "displayName": "macOS Universal",
-      "description": "Build for macOS 11.0+ (Universal binary)",
+      "description": "Build for macOS 12.0+ (Universal binary)",
       "inherits": ["template"],
       "binaryDir": "${sourceDir}/build_macos",
       "condition": {
@@ -28,7 +28,7 @@
       "generator": "Xcode",
       "warnings": {"dev": true, "deprecated": true},
       "cacheVariables": {
-        "CMAKE_OSX_DEPLOYMENT_TARGET": "11.0",
+        "CMAKE_OSX_DEPLOYMENT_TARGET": "12.0",
         "CMAKE_OSX_ARCHITECTURES": "arm64;x86_64",
         "CODESIGN_IDENTITY": "$penv{CODESIGN_IDENT}",
         "CODESIGN_TEAM": "$penv{CODESIGN_TEAM}"
@@ -38,7 +38,7 @@
       "name": "macos-ci",
       "inherits": ["macos"],
       "displayName": "macOS Universal CI build",
-      "description": "Build for macOS 11.0+ (Universal binary) for CI",
+      "description": "Build for macOS 12.0+ (Universal binary) for CI",
       "generator": "Xcode",
       "cacheVariables": {
         "CMAKE_COMPILE_WARNING_AS_ERROR": true,

--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ Any other options, or errors: See [release page](https://distroav.org/download) 
 
 ## Requirements
 
-* [OBS v31.0 or higher](https://github.com/obsproject/obs-studio/releases) (Qt6, x64/ARM64/AppleSilicon)
+* [OBS v31.1.1 or higher](https://github.com/obsproject/obs-studio/releases) (Qt6, x64/ARM64/AppleSilicon)
 * [NDI Runtime v6.3 or higher](https://github.com/DistroAV/DistroAV/wiki/1.-Installation#required---ndi-runtime)
 
 # Troubleshooting

--- a/build-aux/.run-format.zsh
+++ b/build-aux/.run-format.zsh
@@ -33,24 +33,24 @@ invoke_formatter() {
 
   case ${formatter} {
     clang)
-      if (( ${+commands[clang-format-17]} )) {
-        local formatter=clang-format-17
+      if (( ${+commands[clang-format-19]} )) {
+        local formatter=clang-format-19
       } elif (( ${+commands[clang-format]} )) {
         local formatter=clang-format
       } else {
-        log_error "No viable clang-format version found (required 17.0.3)"
+        log_error "No viable clang-format version found (required 19.1.1)"
         exit 2
       }
 
       local -a formatter_version=($(${formatter} --version))
 
-      if ! is-at-least 17.0.3 ${formatter_version[-1]}; then
-        log_error "clang-format is not version 17.0.3 or above (found ${formatter_version[-1]}."
+      if ! is-at-least 19.1.1 ${formatter_version[-1]}; then
+        log_error "clang-format is not version 19.1.1 or above (found ${formatter_version[-1]}."
         exit 2
       fi
 
-      if ! is-at-least ${formatter_version[-1]} 17.0.3; then
-        log_error "clang-format is more recent than version 17.0.3 (found ${formatter_version[-1]})."
+      if ! is-at-least ${formatter_version[-1]} 19.1.1; then
+        log_error "clang-format is more recent than version 19.1.1 (found ${formatter_version[-1]})."
         exit 2
       fi
 

--- a/build-aux/.run-format.zsh
+++ b/build-aux/.run-format.zsh
@@ -45,7 +45,7 @@ invoke_formatter() {
       local -a formatter_version=($(${formatter} --version))
 
       if ! is-at-least 19.1.1 ${formatter_version[-1]}; then
-        log_error "clang-format is not version 19.1.1 or above (found ${formatter_version[-1]}."
+        log_error "clang-format is not version 19.1.1 or above (found ${formatter_version[-1]})."
         exit 2
       fi
 
@@ -95,7 +95,7 @@ invoke_formatter() {
         local gersemi_version=($(gersemi --version))
 
         if ! is-at-least 0.12.0 ${gersemi_version[2]}; then
-          log_error "gersemi is not version 0.12.0 or above (found ${gersemi_version[2]}."
+          log_error "gersemi is not version 0.12.0 or above (found ${gersemi_version[2]})."
           exit 2
         fi
       }

--- a/buildspec.json
+++ b/buildspec.json
@@ -1,33 +1,33 @@
 {
     "dependencies": {
         "obs-studio": {
-            "version": "31.0.4",
+            "version": "31.1.1",
             "baseUrl": "https://github.com/obsproject/obs-studio/archive/refs/tags",
             "label": "OBS sources",
             "hashes": {
-                "macos": "f0b53f0acd05ac0dc3044bd3700740f9d2b7a13504d55c0107468e84a860742b",
-                "windows-x64": "8e29030aa9ab75878b46ac3cb1045ad0e3cc3eb92c425a8b22b9b1d7b629dded"
+                "macos": "39751f067bacc13d44b116c5138491b5f1391f91516d3d590d874edd21292291",
+                "windows-x64": "2c8427c10b55ac6d68008df2e9a3e82f4647aaad18f105e30d4713c2de678ccf"
             }
         },
         "prebuilt": {
-            "version": "2024-09-12",
+            "version": "2025-07-11",
             "baseUrl": "https://github.com/obsproject/obs-deps/releases/download",
             "label": "Pre-Built obs-deps",
             "hashes": {
-                "macos": "c857b211ee378772994b632036e1e5befe66b37e85286cb8e3cefc1435d5220a",
-                "windows-x64": "d4a4f194591766891ad3c0b267deec3c4b85239c8fe557273559927456aeedbb"
+                "macos": "495687e63383d1a287684b6e2e9bfe246bb8f156fe265926afb1a325af1edd2a",
+                "windows-x64": "c8c642c1070dc31ce9a0f1e4cef5bb992f4bff4882255788b5da12129e85caa7"
             }
         },
         "qt6": {
-            "version": "2024-09-12",
+            "version": "2025-07-11",
             "baseUrl": "https://github.com/obsproject/obs-deps/releases/download",
             "label": "Pre-Built Qt6",
             "hashes": {
-                "macos": "34a2de6b7f4d4d58fc5a15a4dba49a61d81a4045d0cedfc1a1f08c0dfb8047cf",
-                "windows-x64": "4d15ce13dbb0a8a2cabcce5ae0da5e80ee589b482a61b2025378465c1da32c4f"
+                "macos": "d3f5f04b6ea486e032530bdf0187cbda9a54e0a49621a4c8ba984c5023998867",
+                "windows-x64": "0e76bf0555dd5382838850b748d3dcfab44a1e1058441309ab54e1a65b156d0a"
             },
             "debugSymbols": {
-                "windows-x64": "dad2351a5c9cd438168e1ed8fb453a2534532252edb555f1001a5e8eb3f1bbd4"
+                "windows-x64": "11b7be92cf66a273299b8f3515c07a5cfb61614b59a4e67f7fc5ecba5e2bdf21"
             }
         }
     },

--- a/cmake/common/buildspec_common.cmake
+++ b/cmake/common/buildspec_common.cmake
@@ -67,7 +67,7 @@ function(_setup_obs_studio)
     COMMAND
       "${CMAKE_COMMAND}" -S "${dependencies_dir}/${_obs_destination}" -B
       "${dependencies_dir}/${_obs_destination}/build_${arch}" -G ${_cmake_generator} "${_cmake_arch}"
-      -DOBS_CMAKE_VERSION:STRING=3.0.0 -DENABLE_PLUGINS:BOOL=OFF -DENABLE_UI:BOOL=OFF
+      -DOBS_CMAKE_VERSION:STRING=3.0.0 -DENABLE_PLUGINS:BOOL=OFF -DENABLE_FRONTEND:BOOL=OFF
       -DOBS_VERSION_OVERRIDE:STRING=${_obs_version} "-DCMAKE_PREFIX_PATH='${CMAKE_PREFIX_PATH}'" ${_is_fresh}
       ${_cmake_extra}
     RESULT_VARIABLE _process_result

--- a/src/plugin-main.h
+++ b/src/plugin-main.h
@@ -26,7 +26,7 @@
 #include <Processing.NDI.Lib.h>
 
 #define PLUGIN_MIN_QT_VERSION "6.0.0"
-#define PLUGIN_MIN_OBS_VERSION "31.0.0"
+#define PLUGIN_MIN_OBS_VERSION "31.1.1"
 #define PLUGIN_MIN_NDI_VERSION "6.3.0"
 
 #define OBS_NDI_ALPHA_FILTER_ID "premultiplied_alpha_filter"


### PR DESCRIPTION

- Updated all the changes made on the obe-plugin-template since last major update -> https://github.com/obsproject/obs-plugintemplate/compare/2c550969af8d723a3d67875379a9e65c1e5780c1..master
Fixes :
- gersemic invalid options
- CI: add libsimde-dev for OBS 32 (ubuntu)
- Bump pre-built & OBS 31.1.1 buildspec
- Increase macOS deployment target to macOS12
- clang-format goes to 19



DistroAV
- Bump the OBS requirement to OBS 31.1.1


