### PR TITLE
Use a separate NDI server for every NDI source receiver

### DIFF
--- a/src/ndi-source.cpp
+++ b/src/ndi-source.cpp
@@ -681,7 +681,7 @@ void *ndi_source_thread(void *data)
 			//
 			video_frame = {};
 			s->ndiLib->framesync_capture_video(ndi_frame_sync, &video_frame,
-							NDIlib_frame_format_type_progressive);
+							   NDIlib_frame_format_type_progressive);
 			if (video_frame.p_data && (video_frame.timestamp > timestamp_video)) {
 				timestamp_video = video_frame.timestamp;
 				// obs_log(LOG_DEBUG, "%s: New Video Frame (Framesync ON): ts=%d tc=%d", obs_source_name, video_frame.timestamp, video_frame.timecode);

--- a/src/plugin-main.h
+++ b/src/plugin-main.h
@@ -30,7 +30,7 @@
 #define PLUGIN_MIN_NDI_VERSION "6.3.0"
 
 #define OBS_NDI_ALPHA_FILTER_ID "premultiplied_alpha_filter"
-
+extern const NDIlib_v6 *load_ndilib();
 extern const NDIlib_v6 *ndiLib;
 
 /*


### PR DESCRIPTION
This is to fix issue 1403 [Bug]: Frame rate of OBS drops when using Keep Active and multiple scenes with 4K 60fps sources.

When Keep Active is chosen, the source receiving thread keeps running whether or not the source is actually showing anywhere in OBS. This effects the performance of OBS by wasting time receiving frames from NDI and passing them to OBS (which ends up ignoring).

One fix is simply to continue to the top of the NDI source thread loop before receiving frames if the source is not being shown. This code code does that.

The other fix is to load a separate NDI library for every source. This keeps NDI from having multiple receivers per library instance.

This PR is a proof of concept, to be tested by various users before deciding to include.