### PR TITLE
Remove Visual Studio generator from presets

### DIFF
--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -56,7 +56,6 @@
         "lhs": "${hostSystemName}",
         "rhs": "Windows"
       },
-      "generator": "Visual Studio 17 2022",
       "architecture": "x64,version=10.0.22621",
       "warnings": {"dev": true, "deprecated": true}
     },


### PR DESCRIPTION
Remove the hard requirement for Visual Studio 17 (VS 2022) and allow to build using Visual Studio 18 (2026)

Should address the error below when using Visual Studio 18 2026
```
[cmake] CMake Error at CMakeLists.txt:5 (project):
[cmake]   Generator
[cmake] 
[cmake]     Visual Studio 17 2022
[cmake] 
[cmake]   could not find any instance of Visual Studio.
[cmake] 
[cmake] 
[cmake] 
[cmake] -- Configuring incomplete, errors occurred!
```
