### PR TITLE
Add filter_add so all filter sender are created at startup

### DIFF
--- a/src/ndi-filter.cpp
+++ b/src/ndi-filter.cpp
@@ -530,15 +530,16 @@ void ndi_filter_tick(void *data, float)
 {
 	auto f = (ndi_filter_t *)data;
 
-	if (!f->ndi_sender) {
-		obs_source_t *parent = obs_filter_get_parent(f->obs_source);
-		if (parent) {
-			ndi_sender_create(f, nullptr);
-		}
-	}
 	obs_get_video_info(&f->ovi);
 
 	f->rendered = false;
+}
+
+void ndi_filter_add(void *data, obs_source_t * /* parent */)
+{
+	auto f = (ndi_filter_t *)data;
+	if (!f->ndi_sender)
+		ndi_sender_create(f, nullptr);
 }
 
 obs_audio_data *ndi_filter_asyncaudio(void *data, obs_audio_data *audio_data)
@@ -626,6 +627,7 @@ obs_source_info create_ndi_filter_info()
 	ndi_filter_info.get_defaults = ndi_filter_getdefaults;
 
 	ndi_filter_info.create = ndi_filter_create;
+	ndi_filter_info.filter_add = ndi_filter_add;
 	ndi_filter_info.destroy = ndi_filter_destroy;
 	ndi_filter_info.update = ndi_filter_update;
 
@@ -650,6 +652,7 @@ obs_source_info create_ndi_audiofilter_info()
 	ndi_filter_info.get_defaults = ndi_filter_getdefaults;
 
 	ndi_filter_info.create = ndi_filter_create_audioonly;
+	ndi_filter_info.filter_add = ndi_filter_add;
 	ndi_filter_info.update = ndi_filter_update;
 	ndi_filter_info.destroy = ndi_filter_destroy_audioonly;
 


### PR DESCRIPTION
This is to fix (https://github.com/DistroAV/DistroAV/issues/1449). 
The regression was caused by "Default NDI name for filters to be `<filter> (<source>)`" (https://github.com/DistroAV/DistroAV/pull/1412)

Instead of checking to see if the sender needs creating in the filter_tick (which is not called on an audio only filter) we now do  that check in the new ndi_filter_add function. 

A side note on implementation: copilot suggested numerous changes to fix this, one of them being to add a filter_add callback. The other changes suggested by copilot were to supposedly fix a race condition which could not be duplicated so those suggested changes were not included in this PR.

***This is a regression and should be included in a hot fix in 6.2.1***