### PR TITLE
fix: log-message return Output Group

### DIFF
--- a/src/forms/output-settings.cpp
+++ b/src/forms/output-settings.cpp
@@ -300,7 +300,7 @@ void OutputSettings::onFormAccepted()
 	obs_log(LOG_INFO,
 		"Output Settings set to MainEnabled='%d', MainName='%s', MainGroup='%s', PreviewEnabled='%d', PreviewName='%s', PreviewGroup='%s'",
 		config->OutputEnabled, config->OutputName.toUtf8().constData(),
-		config->PreviewOutputGroups.toUtf8().constData(), config->PreviewOutputEnabled,
+		config->OutputGroups.toUtf8().constData(), config->PreviewOutputEnabled,
 		config->PreviewOutputName.toUtf8().constData(), config->PreviewOutputGroups.toUtf8().constData());
 
 	config->Save();


### PR DESCRIPTION
fix: Preview Output group returned instead of Main Output Group

simple fix on the error log that did not return the correct value for the NDI Output Main Group Settings